### PR TITLE
Ensure gem is fully tested and robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 /spec/reports/
 /tmp/
 /dist/
+/vendor/
+/vendor/bundle/
+/test/tmp/
 
 TODO

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+    ansi (1.5.0)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
@@ -89,6 +90,7 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -114,6 +116,11 @@ GEM
     maxmind-db (1.2.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
+    minitest-reporters (1.7.1)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     net-imap (0.5.0)
       date
       net-protocol
@@ -214,6 +221,18 @@ GEM
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+    sqlite3 (2.7.3-aarch64-linux-gnu)
+    sqlite3 (2.7.3-arm-linux-gnu)
+    sqlite3 (2.7.3-arm64-darwin)
+    sqlite3 (2.7.3-x86-linux-gnu)
+    sqlite3 (2.7.3-x86_64-darwin)
+    sqlite3 (2.7.3-x86_64-linux-gnu)
     stringio (3.1.1)
     thor (1.3.2)
     timeout (0.4.1)
@@ -242,9 +261,13 @@ PLATFORMS
 
 DEPENDENCIES
   footprinted!
+  minitest (>= 5.20)
+  minitest-reporters (>= 1.6)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.7)
+  simplecov (>= 0.22)
+  sqlite3 (>= 1.4)
 
 BUNDLED WITH
    2.5.17

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,12 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-task default: %i[]
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.verbose = true
+end
+
+task default: [:test]

--- a/footprinted.gemspec
+++ b/footprinted.gemspec
@@ -38,4 +38,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.7"
+  spec.add_development_dependency "minitest", ">= 5.20"
+  spec.add_development_dependency "minitest-reporters", ">= 1.6"
+  spec.add_development_dependency "simplecov", ">= 0.22"
+  spec.add_development_dependency "sqlite3", ">= 1.4"
 end

--- a/lib/footprinted/model.rb
+++ b/lib/footprinted/model.rb
@@ -34,7 +34,7 @@ module Footprinted
     # - has_trackable(association_name): Sets up a custom association for tracking activities.
     #   This method dynamically defines a tracking method based on the given association name.
     #
-    # - track_activity(ip, user = nil): Default method provided to track activities. It logs
+    # - track_activity(ip, user = nil, activity_type = nil): Default method provided to track activities. It logs
     #   the IP address, and optionally, the user involved in the activity. This method can be
     #   overridden in the model including this module for custom behavior.
     #
@@ -66,8 +66,8 @@ module Footprinted
     end
 
     # Fallback method for tracking activity. This will be overridden if has_trackable is called.
-    def track_activity(ip:, user: nil, activity_type: nil)
-      trackable_activities.create(ip: ip, user: user, activity_type: activity_type)
+    def track_activity(ip:, performer: nil, activity_type: nil)
+      trackable_activities.create(ip: ip, performer: performer, activity_type: activity_type)
     end
   end
 end

--- a/test/footprinted/configuration_test.rb
+++ b/test/footprinted/configuration_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FootprintedConfigurationTest < Minitest::Test
+  def setup
+    Footprinted.reset
+  end
+
+  def test_configuration_returns_configuration_instance
+    assert_instance_of Footprinted::Configuration, Footprinted.configuration
+  end
+
+  def test_configure_yields_configuration
+    yielded = nil
+    Footprinted.configure { |c| yielded = c }
+    assert_instance_of Footprinted::Configuration, yielded
+  end
+
+  def test_reset_creates_new_configuration
+    original = Footprinted.configuration
+    Footprinted.configure { |_c| }
+    Footprinted.reset
+    refute_same original, Footprinted.configuration
+  end
+end

--- a/test/footprinted/generators/install_generator_test.rb
+++ b/test/footprinted/generators/install_generator_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators/test_case"
+require "generators/footprinted/install_generator"
+
+class FootprintedInstallGeneratorTest < Rails::Generators::TestCase
+  tests Footprinted::Generators::InstallGenerator
+  destination File.expand_path("../../tmp/generator", __dir__)
+
+  setup :prepare_destination
+
+  def test_creates_migration_file
+    run_generator
+
+    files = Dir[File.join(destination_root, "db/migrate/*.rb")]
+    assert_equal 1, files.size
+
+    content = File.read(files.first)
+    assert_includes content, "create_table :trackable_activities"
+    assert_includes content, "t.inet :ip"
+    assert_includes content, ":trackable, polymorphic: true"
+    assert_includes content, ":performer, polymorphic: true"
+    assert_includes content, "t.text :activity_type, null: false"
+  end
+end

--- a/test/footprinted/model_test.rb
+++ b/test/footprinted/model_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FootprintedModelTest < Minitest::Test
+  include ActiveSupport::Testing::TimeHelpers
+
+  def setup
+    TrackdownStub.enable!
+  end
+
+  def teardown
+    TrackdownStub.disable!
+  end
+
+  def test_includes_trackable_activities_association
+    profile = Profile.create!(name: "A")
+    assert_respond_to profile, :trackable_activities
+  end
+
+  class UserWithViews < Profile
+    self.table_name = "profiles"
+    has_trackable :profile_views
+  end
+
+  def test_has_trackable_defines_association_and_tracking_method
+    profile = UserWithViews.create!(name: "X")
+    assert_respond_to profile, :profile_views
+    assert_respond_to profile, :track_profile_view
+
+    performer = Account.create!(email: "p@example.com")
+    record = profile.track_profile_view(ip: "1.2.3.4", performer: performer)
+
+    assert_instance_of Footprinted::TrackableActivity, record
+    assert_equal "profile_view", record.activity_type
+    assert_equal performer, record.performer
+    assert_equal profile.id, record.trackable_id
+    assert_equal "Profile", record.trackable_type
+    assert record.trackable.is_a?(Profile)
+    assert_equal "US", record.country
+    assert_equal "New York", record.city
+  end
+
+  class UserWithDownloads < Profile
+    self.table_name = "profiles"
+    has_trackable :downloads
+  end
+
+  def test_custom_tracking_method_raises_on_validation_error
+    profile = UserWithDownloads.create!(name: "X")
+    assert_raises ActiveRecord::RecordInvalid do
+      profile.track_download(ip: nil)
+    end
+  end
+
+  def test_fallback_track_activity_creates_record_with_activity_type_and_performer
+    profile = Profile.create!(name: "Fallback")
+    performer = Account.create!(email: "p@example.com")
+
+    record = profile.track_activity(ip: "5.6.7.8", performer: performer, activity_type: "test")
+
+    assert record.persisted?
+    assert_equal "test", record.activity_type
+    assert_equal performer, record.performer
+    assert_equal profile, record.trackable
+  end
+
+  class UserWithViewsDependent < Profile
+    self.table_name = "profiles"
+    has_trackable :views
+  end
+
+  def test_dependent_destroy_cascades
+    profile = UserWithViewsDependent.create!(name: "X")
+    profile.track_view(ip: "9.9.9.9")
+    assert_equal 1, Footprinted::TrackableActivity.count
+
+    profile.destroy
+    assert_equal 0, Footprinted::TrackableActivity.count
+  end
+end

--- a/test/footprinted/railtie_test.rb
+++ b/test/footprinted/railtie_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FootprintedRailtieTest < Minitest::Test
+  def test_railtie_loads
+    require "footprinted/railtie"
+    assert defined?(Footprinted::Railtie)
+  end
+
+  def test_generator_registered
+    require "footprinted/railtie"
+    assert defined?(::Footprinted::Generators::InstallGenerator)
+  end
+end

--- a/test/footprinted/trackable_activity_test.rb
+++ b/test/footprinted/trackable_activity_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FootprintedTrackableActivityTest < Minitest::Test
+  include ActiveSupport::Testing::TimeHelpers
+
+  def setup
+    TrackdownStub.enable!
+  end
+
+  def teardown
+    TrackdownStub.disable!
+  end
+
+  def build_profile(name: "X")
+    Profile.create!(name: name)
+  end
+
+  def test_validations
+    activity = Footprinted::TrackableActivity.new
+    refute activity.valid?
+    assert_includes activity.errors.attribute_names, :ip
+    assert_includes activity.errors.attribute_names, :activity_type
+    assert_includes activity.errors.attribute_names, :trackable
+  end
+
+  def test_associations
+    profile = build_profile
+    activity = Footprinted::TrackableActivity.create!(ip: "1.1.1.1", activity_type: "x", trackable: profile)
+    assert_equal profile, activity.trackable
+    assert_nil activity.performer
+
+    performer = Account.create!(email: "p@example.com")
+    activity.update!(performer: performer)
+    assert_equal performer, activity.performer
+  end
+
+  def test_geolocation_success_sets_country_and_city
+    profile = build_profile
+    activity = Footprinted::TrackableActivity.create!(ip: "1.1.1.1", activity_type: "x", trackable: profile)
+    assert_equal "US", activity.country
+    assert_equal "New York", activity.city
+  end
+
+  def test_no_raise_when_trackdown_missing
+    profile = build_profile
+    TrackdownStub.disable!
+    activity = Footprinted::TrackableActivity.create!(ip: "1.1.1.1", activity_type: "x", trackable: profile)
+    assert activity.persisted?
+    assert_nil activity.country
+    assert_nil activity.city
+  ensure
+    TrackdownStub.enable!
+  end
+
+  def test_no_raise_when_database_missing
+    profile = build_profile
+    TrackdownStub.set_database_exists!(false)
+    activity = Footprinted::TrackableActivity.create!(ip: "1.1.1.1", activity_type: "x", trackable: profile)
+    assert activity.persisted?
+    assert_nil activity.country
+    assert_nil activity.city
+  ensure
+    TrackdownStub.set_database_exists!(true)
+  end
+
+  def test_logs_and_continues_when_locate_raises
+    TrackdownStub.set_locate_raising!("test error")
+    profile = build_profile
+    activity = Footprinted::TrackableActivity.create!(ip: "1.1.1.1", activity_type: "x", trackable: profile)
+    assert_nil activity.country
+    assert_nil activity.city
+    assert activity.persisted?
+  end
+
+  def test_scopes_and_class_methods
+    Footprinted::TrackableActivity.delete_all
+    profile = build_profile
+    performer = Account.create!(email: "p@example.com")
+
+    travel_to Time.utc(2024, 1, 1, 12) do
+      TrackdownStub.enable!(country: "US", city: "NY")
+      Footprinted::TrackableActivity.create!(ip: "1.1.1.1", activity_type: "view", trackable: profile, performer: performer)
+    end
+    travel_to Time.utc(2024, 1, 2, 12) do
+      TrackdownStub.enable!(country: "UK", city: "London")
+      Footprinted::TrackableActivity.create!(ip: "2.2.2.2", activity_type: "view", trackable: profile)
+    end
+    travel_to Time.utc(2024, 1, 3, 12) do
+      TrackdownStub.enable!(country: "US", city: "Boston")
+      Footprinted::TrackableActivity.create!(ip: "3.3.3.3", activity_type: "download", trackable: profile)
+    end
+
+    assert_equal 2, Footprinted::TrackableActivity.by_activity("view").count
+    assert_equal 2, Footprinted::TrackableActivity.by_country("US").count
+    assert_equal ["download", "view"].sort, Footprinted::TrackableActivity.activity_types.sort
+    assert_equal ["UK", "US"].sort, Footprinted::TrackableActivity.countries.sort
+
+    # performed_by
+    assert_equal 1, Footprinted::TrackableActivity.performed_by(performer).count
+
+    # recent ordering
+    recent = Footprinted::TrackableActivity.recent.to_a
+    assert_operator recent.first.created_at, :>=, recent.last.created_at
+
+    # between and last_days
+    range = Footprinted::TrackableActivity.between(Time.utc(2024, 1, 2), Time.utc(2024, 1, 3, 23, 59, 59))
+    assert_equal 2, range.count
+
+    # last_days depends on current time; ensure the 3 records we created are included with a sufficiently large window
+    assert Footprinted::TrackableActivity.last_days(1000).count >= 3
+  end
+end

--- a/test/footprinted/version_test.rb
+++ b/test/footprinted/version_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FootprintedVersionTest < Minitest::Test
+  def test_version_present
+    refute_nil ::Footprinted::VERSION
+    assert_match(/\A\d+\.\d+\.\d+\z/, ::Footprinted::VERSION)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+
+# Coverage
+begin
+  require "simplecov"
+  SimpleCov.start do
+    enable_coverage :branch
+    add_filter "/test/"
+  end
+rescue LoadError
+  warn "SimpleCov not available"
+end
+
+require "minitest/autorun"
+require "minitest/reporters"
+Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)
+
+require "active_support"
+require "active_support/core_ext/numeric/time"
+require "active_support/testing/time_helpers"
+require "active_record"
+require "logger"
+
+# Minimal Rails logger for model callback rescues
+require "rails"
+Rails.logger = Logger.new($stdout)
+
+# Establish in-memory database
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Base.logger = Logger.new($stdout)
+
+# Define schema for tests
+ActiveRecord::Schema.define do
+  create_table :profiles, force: true do |t|
+    t.string :name
+    t.timestamps
+  end
+
+  create_table :accounts, force: true do |t|
+    t.string :email
+    t.timestamps
+  end
+
+  create_table :trackable_activities, force: true do |t|
+    t.string  :ip, null: false
+    t.text    :country
+    t.text    :city
+    t.string  :trackable_type, null: false
+    t.integer :trackable_id,   null: false
+    t.string  :performer_type
+    t.integer :performer_id
+    t.text    :activity_type, null: false
+    t.timestamps
+  end
+
+  add_index :trackable_activities, [:trackable_type, :trackable_id, :activity_type]
+  add_index :trackable_activities, :activity_type
+  add_index :trackable_activities, :country
+end
+
+require "footprinted"
+
+# Test models
+class Profile < ActiveRecord::Base
+  include Footprinted::Model
+end
+
+class Account < ActiveRecord::Base
+end
+
+# Ensure clean state between tests
+class Minitest::Test
+  def after_teardown
+    Footprinted::TrackableActivity.delete_all
+    Profile.delete_all
+    Account.delete_all
+    super
+  end
+end
+
+# Helper stubs for Trackdown
+module TrackdownStub
+  Location = Struct.new(:country_code, :city)
+
+  def self.enable!(country: "US", city: "New York")
+    Object.send(:remove_const, :Trackdown) if Object.const_defined?(:Trackdown)
+    Object.const_set(:Trackdown, Module.new)
+    Trackdown.define_singleton_method(:database_exists?) { true }
+    Trackdown.define_singleton_method(:locate) { |_ip| Location.new(country, city) }
+  end
+
+  def self.disable!
+    Object.send(:remove_const, :Trackdown) if Object.const_defined?(:Trackdown)
+  end
+
+  def self.set_database_exists!(value)
+    Trackdown.define_singleton_method(:database_exists?) { value }
+  end
+
+  def self.set_locate_raising!(message = "boom")
+    Trackdown.define_singleton_method(:locate) { |_ip| raise StandardError, message }
+  end
+end


### PR DESCRIPTION
Adds a comprehensive Minitest suite and fixes a bug in `Footprinted::Model#track_activity` to ensure robust testing and correct behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-85fb8d2c-180e-4371-b76a-820d09f73dc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85fb8d2c-180e-4371-b76a-820d09f73dc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

