### PR TITLE
Change Railtie to Engine so app/jobs is autoloaded

### DIFF
--- a/lib/footprinted.rb
+++ b/lib/footprinted.rb
@@ -25,4 +25,4 @@ module Footprinted
   end
 end
 
-require "footprinted/railtie" if defined?(Rails)
+require "footprinted/engine" if defined?(Rails)

--- a/lib/footprinted/engine.rb
+++ b/lib/footprinted/engine.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Footprinted
-  class Railtie < Rails::Railtie
+  class Engine < Rails::Engine
     initializer "footprinted.initialize" do
       ActiveSupport.on_load(:active_record) do
         extend Footprinted::Model


### PR DESCRIPTION
## Summary
- **Renames `Railtie` to `Engine`** so the gem's `app/` directory (specifically `app/jobs/footprinted/track_job.rb`) is added to the host app's autoload paths
- Without this, `config.async = true` raises `NameError: uninitialized constant Footprinted::TrackJob` because `Railtie` does not autoload `app/` subdirectories — only `Engine` does
- Zero behavior change beyond fixing autoloading; the `Engine` class inherits from `Railtie` and keeps all existing initializer/generator hooks

## Test plan
- [x] `bundle exec rake test` — 165 tests, 0 failures, 0 errors
- [x] Verified `Footprinted::TrackJob.perform_now(...)` creates footprints correctly in host app
- [x] Verified `product.track(...)` with `config.async = true` enqueues the job (does not write inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)